### PR TITLE
chore: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/lint_test_promote.yml
+++ b/.github/workflows/lint_test_promote.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       # replace "master" with any valid ref
       - name: Run Shellcheck
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [shell_lint]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
         # TODO: Break out into common bits - perhaps even the "uses" type system.
       - name: Merge to master
-        uses: devmasx/merge-branch@v1.3.1
+        uses: devmasx/merge-branch@a1752b9ba42bb417ec19be7dc974e2faf77d3ef2 # v1.3.1
         with:
           type: now
           from_branch: devel
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ github.token }}
 
       - name: Bump version and push tag
-        uses: mathieudutour/github-tag-action@v4.6
+        uses: mathieudutour/github-tag-action@bcb832838e1612ff92089d914bccc0fd39458223 # v4.6
         with:
           release_branches: devel
           tag_prefix: ''


### PR DESCRIPTION
## Summary
- Pins all GitHub Actions to immutable commit SHAs instead of mutable tags
- Prevents supply chain attacks where a compromised tag could inject malicious code
- Dependabot will keep pinned SHAs up to date automatically

## Test plan
- [ ] Verify CI passes with pinned actions